### PR TITLE
Make a proper tool, make installable, switch to sparse matrices everywhere, allow multiple regions on different chromosomes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,125 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ output_cool_file - name of new cool file that will be generated.
 Additional arguments you can add:
 
 --mult_factor - float that will be used for multiplicating around ROI (see original manuscript, default 1.54).
+
 --IC_steps - maximum number of iterative correction steps that can be applied (default 20)
+
 --tolerance - float for required variance in coverage required for iterative correction convergence (default 10^-5)
 
 

--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ Additional arguments you can add:
 
 
 # IMPORTANT
-Script generate new file with normalized matrix, but delete raw matrix. So for parsing new cool file you should use balance=False.
-We fix this in future.
+The tool generates a new .cool file with normalized matrix written directly without weights. To load data from the new cool file you should use balance=False.
+We might fix this in future.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ctale_normalize cool_file ROI_coordinates output_cool_file
 cool_file - Cool file with C-TALE HiC map.
 
 ROI_coordinates - Genomics coordinates in bp for Region of Interest in UCSC format.
-<chr> can be number or letter if you generate cool using hiclib, but should match the chromosome name in the cool_file.
+Chromosome name should match the chromosome name in the cool_file.
 For example, chr1:150,000-151,000;chr2:320000-420000 - if capturing multiple regions (not more than 1 per chromosome!), separate them with a semicolon.
 
 output_cool_file - name of new cool file that will be generated.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 Code and examples for C-TALE normalization
 
 *All scripts are provided as is, without any warrenty and for use at your own risk. This is not the release of a software package. We are only providing this information and code in addition to a description of methods for making it easier to reproduce our analyses. We are not providing any support for these scripts.*
+
+# Installation
+
+Install using pip, e.g.
+`pip install https://github.com/ArtemLuzhin/C-TALE-Normalization/archive/master.zip`
+
 # Usage:
 
 Minimal command ot run your C-TALE normalization:

--- a/README.md
+++ b/README.md
@@ -3,18 +3,24 @@ Code and examples for C-TALE normalization
 
 *All scripts are provided as is, without any warrenty and for use at your own risk. This is not the release of a software package. We are only providing this information and code in addition to a description of methods for making it easier to reproduce our analyses. We are not providing any support for these scripts.*
 # Usage:
-python2 C-TALE-normalize.py cool_file chr ROI_start ROI_end resolution coefficient output_cool_file
 
+Minimal command ot run your C-TALE normalization:
+ctale_normalize cool_file ROI_coordinates output_cool_file
 
 cool_file - Cool file with C-TALE HiC map.
 
-chr, ROI_start, ROI_end - Genomics coordinates in bp of Region of interest. <chr> can be number or letter if you generate cool using hiclib.
-
-resolution -resolution of C-TALE HiC map in bp.
-
-coefficient - float that will be used for multiplicating around ROI (see original manuscript).
+ROI_coordinates - Genomics coordinates in bp for Region of Interest in UCSC format.
+<chr> can be number or letter if you generate cool using hiclib, but should match the chromosome name in the cool_file.
+For example, chr1:150,000-151,000;chr2:320000-420000 - if capturing multiple regions (not more than 1 per chromosome!), separate them with a semicolon.
 
 output_cool_file - name of new cool file that will be generated.
+
+Additional arguments you can add:
+
+--mult_factor - float that will be used for multiplicating around ROI (see original manuscript, default 1.54).
+--IC_steps - maximum number of iterative correction steps that can be applied (default 20)
+--tolerance - float for required variance in coverage required for iterative correction convergence (default 10^-5)
+
 
 # IMPORTANT
 Script generate new file with normalized matrix, but delete raw matrix. So for parsing new cool file you should use balance=False.

--- a/ctale_normalize/C_TALE_normalize.py
+++ b/ctale_normalize/C_TALE_normalize.py
@@ -3,7 +3,7 @@ import pandas as pd
 import numpy as np
 import cooler
 import scipy.stats
-from scipy import sparse
+from scipy import sparse, stats
 import sys
 from natsort import natsorted
 
@@ -39,35 +39,6 @@ def CTALE_norm_multiplicate(mtx, ROI_start, ROI_end, resolution,
     normalized[i_lower] = normalized.T[i_lower]
     return(normalized)
 
-def norm_mtx(mtx, func=scipy.stats.gmean):
-    normalized = np.zeros_like(mtx)
-    for i in range(mtx.shape[0]):
-        normalized[i,i:]=mtx[i,i:]/(np.sum(mtx[i,i:])+np.sum(mtx[:i,i])) #left
-        normalized[:i,i]=mtx[:i,i]/(np.sum(mtx[:i,i])+np.sum(mtx[i,i:])) #up
-    for i in range(mtx.shape[0]):
-        for j in range(i+1, mtx.shape[0]):
-            normalized[i,j]=mtx[i,j]/func([np.sum(mtx[i,:]),np.sum(mtx[:,j])])
-    i_lower = np.tril_indices(normalized.shape[0], -1) #creates symmetric matrix
-    normalized[i_lower] = normalized.T[i_lower]
-    return normalized
-
-def CTALE_norm(mtx, ROI_start, ROI_end, resolution, func=scipy.stats.gmean):
-    """Same as CTALE_norm_multiplicate function but without multiplication.
-    mtx- matrix of individual chromosome/region +/- distance
-    ROI_start - first coordinate of C-TALE region(bp)
-    ROI_end - last coordinate of C-TALE region(bp)
-    resolution - C-TALE map resolution(bp)
-    func - function for calculating mean, can be numpy.mean,numpy.median and etc. Default scipy.stats.gmean
-    returns normalized matrix"""
-    start_bin = ROI_start//resolution
-    end_bin = ROI_end//resolution
-    #fill main diagonal with zeros
-    mtx.setdiag(0)
-    submtx = mtx[start_bin:end_bin+1, start_bin:end_bin+1].todense()
-    normed = norm_mtx(submtx)
-    mtx[start_bin:end_bin+1, start_bin:end_bin+1] = sparse.csr_matrix(normed)
-    return mtx
-
 def multiplicate(mtx, ROI_start, ROI_end, resolution, mult=1.54):
     """mtx- matrix of individual chromosome/region +/- distance
     ROI_start - first coordinate of C-TALE region(bp)
@@ -85,9 +56,37 @@ def multiplicate(mtx, ROI_start, ROI_end, resolution, mult=1.54):
                                                             start_bin:end_bin+1]
     return new_mtx
 
-def CTALE_norm_iterative(mtx, ROI_start, ROI_end, resolution,
-                         func=scipy.stats.gmean, mult=1.54, steps=20,
-                         tolerance=1e-5):
+def get_cov_var(mtx, startbin, endbin):
+    cov1 = np.asarray(mtx.sum(axis=0)).ravel()
+    cov2 = np.asarray(mtx.sum(axis=1)).ravel()
+    
+    cov1[:startbin] = 1
+    cov1[endbin+1:] = 1
+    cov1[endbin+1:] = 1
+    
+    cov2[:startbin] = 1
+    cov2[endbin+1:] = 1
+    
+    cov = stats.gmean([cov1, cov2], axis=0)
+    var = np.std(cov[startbin:endbin+1])
+    
+    return cov1, cov2, var
+
+def CTALE_norm(mtx, ROI_start, ROI_end, resolution):
+    """Single iteration of CTALE balancing
+    mtx - matrix of individual chromosome/region +/- distance
+    ROI_start - first coordinate of C-TALE region(bp)
+    ROI_end - last coordinate of C-TALE region(bp)
+    resolution - C-TALE map resolution(bp)
+    returns normalized matrix and variance at this iteration"""
+    start_bin = ROI_start//resolution
+    end_bin = ROI_end//resolution
+    cov1, cov2, var = get_cov_var(mtx, start_bin, end_bin)
+    mtx = mtx.multiply(1/cov1).multiply(1/cov2[np.newaxis].T).tocsr()
+    return mtx, var
+
+def CTALE_norm_iterative(mtx, ROI_start, ROI_end, resolution, mult=1.54,
+                         target_var=10**-6, steps=20):
     """Main function that perform normalization until variance>tolerance
     mtx- matrix of individual chromosome/region +/- distance
     ROI_start - first coordinate of C-TALE region(bp)
@@ -100,20 +99,23 @@ def CTALE_norm_iterative(mtx, ROI_start, ROI_end, resolution,
     returns normalized matrix"""
     start_bin = ROI_start//resolution
     end_bin = ROI_end//resolution
+    
     out = multiplicate(mtx=mtx, ROI_start=ROI_start, ROI_end=ROI_end,
-                       resolution=resolution, mult=mult)
-    for s in range(steps):
-        out = CTALE_norm(out, ROI_start, ROI_end, resolution, func=func)
-        var = np.var(np.sum(out[start_bin:end_bin+1, start_bin:end_bin+1],
-                            axis=1))
-        print('Variance is: ',var)
-        if var<tolerance:
-            print('Variance < ',tolerance)
-            break
-    factor = out[start_bin:end_bin+1, start_bin:end_bin+1].sum().sum()/mtx[start_bin:end_bin+1, start_bin:end_bin+1].sum().sum()
-    out *= factor
-    out[start_bin:end_bin+1, start_bin:end_bin+1] /= factor
-    return out
+                   resolution=resolution, mult=mult)
+    
+    cov1, cov2, var = get_cov_var(out, start_bin, end_bin)
+    print('Original var:', var)
+    for i in range(steps):
+        out, var = CTALE_norm(out, ROI_start, ROI_end, resolution)
+        print('Iteration %s: var: %s' % (i+1, var))
+        if var < target_var:
+            print('Variance below %s' % target_var)
+#            factor = out[start_bin:end_bin+1, start_bin:end_bin+1].sum()/mtx[start_bin:end_bin+1, start_bin:end_bin+1].sum()
+#            out *= factor
+#            out[start_bin:end_bin+1, start_bin:end_bin+1] /= factor
+            return out
+    raise ValueError('Too many interation without convergence')
+
 
 def get_pixels(mtx, zero_id=0):
     mtx_upper_diag = sparse.triu(mtx, k=0)

--- a/ctale_normalize/C_TALE_normalize.py
+++ b/ctale_normalize/C_TALE_normalize.py
@@ -110,6 +110,9 @@ def CTALE_norm_iterative(mtx, ROI_start, ROI_end, resolution,
         if var<tolerance:
             print('Variance < ',tolerance)
             break
+    factor = out[start_bin:end_bin+1, start_bin:end_bin+1].sum().sum()/mtx[start_bin:end_bin+1, start_bin:end_bin+1].sum().sum()
+    out *= factor
+    out[start_bin:end_bin+1, start_bin:end_bin+1] /= factor
     return out
 
 def get_pixels(mtx, zero_id=0):

--- a/ctale_normalize/C_TALE_normalize.py
+++ b/ctale_normalize/C_TALE_normalize.py
@@ -89,6 +89,7 @@ def CTALE_norm(mtx, ROI_start, ROI_end, resolution):
     start_bin = ROI_start//resolution
     end_bin = ROI_end//resolution
     cov, var = get_cov_var(mtx, start_bin, end_bin)
+    cov = (cov-1)*0.8 + 1
     mtx = mtx.multiply(1/cov).multiply(1/cov[np.newaxis].T).tocsr()
     cov, var = get_cov_var(mtx, start_bin, end_bin)
     return mtx, var

--- a/ctale_normalize/C_TALE_normalize.py
+++ b/ctale_normalize/C_TALE_normalize.py
@@ -3,6 +3,7 @@ import pandas as pd
 import numpy as np
 import cooler
 import scipy.stats
+from scipy import sparse
 import sys
 from natsort import natsorted
 
@@ -38,6 +39,18 @@ def CTALE_norm_multiplicate(mtx, ROI_start, ROI_end, resolution,
     normalized[i_lower] = normalized.T[i_lower]
     return(normalized)
 
+def norm_mtx(mtx, func=scipy.stats.gmean):
+    normalized = np.zeros_like(mtx)
+    for i in range(mtx.shape[0]):
+        normalized[i,i:]=mtx[i,i:]/(np.sum(mtx[i,i:])+np.sum(mtx[:i,i])) #left
+        normalized[:i,i]=mtx[:i,i]/(np.sum(mtx[:i,i])+np.sum(mtx[i,i:])) #up
+    for i in range(mtx.shape[0]):
+        for j in range(i+1, mtx.shape[0]):
+            normalized[i,j]=mtx[i,j]/func([np.sum(mtx[i,:]),np.sum(mtx[:,j])])
+    i_lower = np.tril_indices(normalized.shape[0], -1) #creates symmetric matrix
+    normalized[i_lower] = normalized.T[i_lower]
+    return normalized
+
 def CTALE_norm(mtx, ROI_start, ROI_end, resolution, func=scipy.stats.gmean):
     """Same as CTALE_norm_multiplicate function but without multiplication.
     mtx- matrix of individual chromosome/region +/- distance
@@ -46,23 +59,14 @@ def CTALE_norm(mtx, ROI_start, ROI_end, resolution, func=scipy.stats.gmean):
     resolution - C-TALE map resolution(bp)
     func - function for calculating mean, can be numpy.mean,numpy.median and etc. Default scipy.stats.gmean
     returns normalized matrix"""
-    normalized=np.zeros(shape=mtx.shape)
-    start_bin=int(ROI_start/resolution)
-    end_bin=int(ROI_end/resolution)
+    start_bin = ROI_start//resolution
+    end_bin = ROI_end//resolution
     #fill main diagonal with zeros
-    np.fill_diagonal(mtx,0)
-    for i in range(start_bin,end_bin):
-        #left=mtx[i,i:]
-        #up=mtx[:i,i]
-        normalized[i,i:]=mtx[i,i:]/(np.sum(mtx[i,i:])+np.sum(mtx[:i,i])) #left
-        normalized[:i,i]=mtx[:i,i]/(np.sum(mtx[:i,i])+np.sum(mtx[i,i:])) #up
-    for i in range(start_bin,end_bin):
-        for j in range(i+1,end_bin):
-            normalized[i,j]=mtx[i,j]/func([np.sum(mtx[i,:]),np.sum(mtx[:,j])])
-    i_lower = np.tril_indices(normalized.shape[0], -1) #creates symmetric matrix
-    normalized[i_lower] = normalized.T[i_lower]
-    return(normalized)
-
+    mtx.setdiag(0)
+    submtx = mtx[start_bin:end_bin+1, start_bin:end_bin+1].todense()
+    normed = norm_mtx(submtx)
+    mtx[start_bin:end_bin+1, start_bin:end_bin+1] = sparse.csr_matrix(normed)
+    return mtx
 
 def multiplicate(mtx, ROI_start, ROI_end, resolution, mult=1.54):
     """mtx- matrix of individual chromosome/region +/- distance
@@ -71,14 +75,15 @@ def multiplicate(mtx, ROI_start, ROI_end, resolution, mult=1.54):
     resolution - C-TALE map resolution(bp)
     mult-coefficient of multiplication around ROI, default=1.54
     Function perform multiplicating of matrix around ROI for selected coefficient"""
-    start_bin=int(ROI_start/resolution)
-    end_bin=int(ROI_end/resolution)
+    start_bin = ROI_start//resolution
+    end_bin = ROI_end//resolution
     #fill main diagonal with zeros
-    np.fill_diagonal(mtx,0)
+    mtx.setdiag(0)
     # first we multiply around region
-    new_mtx=mtx*mult
-    new_mtx[start_bin:end_bin,start_bin:end_bin]=mtx[start_bin:end_bin,start_bin:end_bin]
-    return(new_mtx)
+    new_mtx = mtx*mult
+    new_mtx[start_bin:end_bin+1, start_bin:end_bin+1] = mtx[start_bin:end_bin+1,
+                                                            start_bin:end_bin+1]
+    return new_mtx
 
 def CTALE_norm_iterative(mtx, ROI_start, ROI_end, resolution,
                          func=scipy.stats.gmean, mult=1.54, steps=20,
@@ -93,23 +98,26 @@ def CTALE_norm_iterative(mtx, ROI_start, ROI_end, resolution,
     steps-number of iterations, by default=20
     tolerance-when variance<tolerance algorithm stops.
     returns normalized matrix"""
-    start_bin=int(ROI_start/resolution)
-    end_bin=int(ROI_end/resolution)
-    out=multiplicate(mtx=mtx,ROI_start=ROI_start,ROI_end=ROI_end,resolution=resolution,mult=mult)
+    start_bin = ROI_start//resolution
+    end_bin = ROI_end//resolution
+    out = multiplicate(mtx=mtx, ROI_start=ROI_start, ROI_end=ROI_end,
+                       resolution=resolution, mult=mult)
     for s in range(steps):
-        out=CTALE_norm(out,ROI_start,ROI_end,resolution,func=func)
-        var=np.var(np.sum(out[start_bin:end_bin,:],axis=1))
+        out = CTALE_norm(out, ROI_start, ROI_end, resolution, func=func)
+        var = np.var(np.sum(out[start_bin:end_bin+1, start_bin:end_bin+1],
+                            axis=1))
         print('Variance is: ',var)
         if var<tolerance:
             print('Variance < ',tolerance)
             break
-    return(out)
+    return out
 
-def get_pixels(mtx):
-    mtx_upper_diag = np.triu(mtx, k=0)
-    smtx=scipy.sparse.csr_matrix(mtx_upper_diag)
-    sc=smtx.tocoo(copy=False)
-    pixels=pd.DataFrame({'bin1_id': sc.row, 'bin2_id': sc.col, 'count': sc.data})
+def get_pixels(mtx, zero_id=0):
+    mtx_upper_diag = sparse.triu(mtx, k=0)
+    sc = mtx_upper_diag.tocoo(copy=False)
+    pixels = pd.DataFrame({'bin1_id': sc.row+zero_id,
+                           'bin2_id': sc.col+zero_id,
+                           'count': sc.data})
     return pixels
 
 def Save_coolfile(coolfile, chroms, mtxs, output_coolfile):
@@ -120,10 +128,12 @@ def Save_coolfile(coolfile, chroms, mtxs, output_coolfile):
     output_coolfile - name of new cool file
     genome - genome assembly id"""
     #create bins
-    bins = pd.concat([coolfile.bins().fetch(chrom)[:] for chrom in chroms])
+    bins = [coolfile.bins().fetch(chrom)[:] for chrom in chroms]
+    bins = pd.concat(bins).reset_index(drop=True)
+    zerobins = dict(bins.groupby('chrom').apply(lambda x: x.index.min()))
     #Create sparse matrix
-    pixels = pd.concat([get_pixels(mtx) for mtx in mtxs])
-    cooler.io.create(output_coolfile, bins, pixels,
+    pixels = pd.concat([get_pixels(mtx, zerobins[chrom]) for mtx, chrom in zip(mtxs, chroms)])
+    cooler.create_cooler(output_coolfile, bins, pixels,
                      assembly=coolfile.info[u'genome-assembly'],
-                     dtype={'count':float})
-    return('Saved')
+                     dtypes={'count':float})
+    return

--- a/ctale_normalize/__init__.py
+++ b/ctale_normalize/__init__.py
@@ -1,0 +1,1 @@
+from .C_TALE_normalize import *

--- a/ctale_normalize/__main__.py
+++ b/ctale_normalize/__main__.py
@@ -5,6 +5,7 @@ from ctale_normalize import CTALE_norm_iterative, Save_coolfile
 import argparse
 import cooler
 import logging
+from natsort import natsorted
 
 def main():
     parser = argparse.ArgumentParser(
@@ -12,7 +13,10 @@ def main():
     parser.add_argument("cooler", type=str,
                         help="Cooler file with your C-TALE data")
     parser.add_argument("coordinates", type=str,
-                        help="Coordinates of the captured region in ucsc format")
+                        help="""Coordinates of the captured region in UCSC
+                        format. If multiple regions (one per chromosome!) were
+                        captured, write comma-separated coordinates for each
+                        of them""")
     parser.add_argument("--mult_factor", type=float, default=1.54,
                         required=False,
                         help="Factor for correction of zone 3")
@@ -30,15 +34,23 @@ def main():
 
     C=cooler.Cooler(args.cooler) #load coolfile
     logging.info('Loaded cool')
-    chrom, start, end = cooler.util.parse_region(args.coordinates)
-    #load raw matrix
-    mtx=C.matrix(balance=False).fetch(chrom)
-    logging.info('Loaded matrix...')
-    #Perform normalization
-    logging.info('Normalization...')
-    N=CTALE_norm_iterative(mtx,start, end, C.binsize, steps=args.IC_steps,
-                           mult=args.mult_factor)
+    regions = args.coordinates .split(',')
+    chroms = []
+    mtxs = []
+    for region in natsorted(regions):
+        chrom, start, end = cooler.util.parse_region(region)
+        if chrom in chroms:
+            raise ValueError("""Two regions are on the same chromosome, this is
+                                not yet supported""")
+        #load raw matrix
+        mtx=C.matrix(balance=False, sparse=True).fetch(chrom)
+        logging.info('Loaded matrix for %s' % chrom)
+        #Perform normalization
+        logging.info('Normalization...')
+        mtxs.append(CTALE_norm_iterative(mtx, start, end, C.binsize, steps=args.IC_steps,
+                               mult=args.mult_factor))
+        chroms.append(chrom)
     logging.info('Save as '+ args.output)
     #Save_coolfile
-    Save_coolfile(C, N, chrom, args.output, C.info[u'genome-assembly'])
+    Save_coolfile(C, chroms, mtxs, args.output)
     logging.info('Finished!')

--- a/ctale_normalize/__main__.py
+++ b/ctale_normalize/__main__.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from ctale_normalize import CTALE_norm_iterative, Save_coolfile
+import argparse
+import cooler
+import logging
+
+def main():
+    parser = argparse.ArgumentParser(
+                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("cooler", type=str,
+                        help="Cooler file with your C-TALE data")
+    parser.add_argument("coordinates", type=str,
+                        help="Coordinates of the captured region in ucsc format")
+    parser.add_argument("--mult_factor", type=float, default=1.54,
+                        required=False,
+                        help="Factor for correction of zone 3")
+    parser.add_argument("--IC_steps", type=int, default=20,
+                        required=False,
+                        help="""Number of steps for iterative correction in
+                                zone 2""")
+    parser.add_argument("output", type=str,
+                        help="Where to save the output")
+
+    args = parser.parse_args()
+
+#    logging.basicConfig(format='%(message)s',
+#                        level=getattr(logging, args.logLevel))
+
+    C=cooler.Cooler(args.cooler) #load coolfile
+    logging.info('Loaded cool')
+    chrom, start, end = cooler.util.parse_region(args.coordinates)
+    #load raw matrix
+    mtx=C.matrix(balance=False).fetch(chrom)
+    logging.info('Loaded matrix...')
+    #Perform normalization
+    logging.info('Normalization...')
+    N=CTALE_norm_iterative(mtx,start, end, C.binsize, steps=args.IC_steps,
+                           mult=args.mult_factor)
+    logging.info('Save as '+ args.output)
+    #Save_coolfile
+    Save_coolfile(C, N, chrom, args.output, C.info[u'genome-assembly'])
+    logging.info('Finished!')

--- a/ctale_normalize/__main__.py
+++ b/ctale_normalize/__main__.py
@@ -34,7 +34,7 @@ def main():
 
     C=cooler.Cooler(args.cooler) #load coolfile
     logging.info('Loaded cool')
-    regions = args.coordinates .split(';')
+    regions = args.coordinates.split(';')
     chroms = []
     mtxs = []
     for region in natsorted(regions):

--- a/ctale_normalize/__main__.py
+++ b/ctale_normalize/__main__.py
@@ -43,7 +43,7 @@ def main():
             raise ValueError("""Two regions are on the same chromosome, this is
                                 not yet supported""")
         #load raw matrix
-        mtx=C.matrix(balance=False, sparse=True).fetch(chrom)
+        mtx = C.matrix(balance=False, sparse=True).fetch(chrom).tocsr()
         logging.info('Loaded matrix for %s' % chrom)
         #Perform normalization
         logging.info('Normalization...')

--- a/ctale_normalize/__main__.py
+++ b/ctale_normalize/__main__.py
@@ -34,7 +34,7 @@ def main():
 
     C=cooler.Cooler(args.cooler) #load coolfile
     logging.info('Loaded cool')
-    regions = args.coordinates .split(',')
+    regions = args.coordinates .split(';')
     chroms = []
     mtxs = []
     for region in natsorted(regions):

--- a/ctale_normalize/__main__.py
+++ b/ctale_normalize/__main__.py
@@ -15,8 +15,9 @@ def main():
     parser.add_argument("coordinates", type=str,
                         help="""Coordinates of the captured region in UCSC
                         format. If multiple regions (one per chromosome!) were
-                        captured, write semicolon-separated coordinates for
-                        each of them""")
+                        captured, semicolon-separated coordinates for each of
+                        them can be used. For example,
+                        chr1:150,000-151,000;chr2:320000-420000""")
     parser.add_argument("--mult_factor", type=float, default=1.54,
                         required=False,
                         help="Factor for correction of zone 3")
@@ -24,6 +25,9 @@ def main():
                         required=False,
                         help="""Number of steps for iterative correction in
                                 zone 2""")
+    parser.add_argument("--tolerance", type=float, default=10**-5,
+                        required=False,
+                        help="""Target variance for iterative correction""")
     parser.add_argument("output", type=str,
                         help="Where to save the output")
 
@@ -49,9 +53,10 @@ def main():
         logging.info('Normalization...')
         mtxs.append(CTALE_norm_iterative(mtx, start, end, C.binsize,
                                          steps=args.IC_steps,
-                                         mult=args.mult_factor))
+                                         mult=args.mult_factor,
+                                         tolerance=args.tolerance))
         chroms.append(chrom)
-    logging.info('Save as '+ args.output)
+    logging.info('Saving as '+ args.output)
     #Save_coolfile
     Save_coolfile(C, chroms, mtxs, args.output)
     logging.info('Finished!')

--- a/ctale_normalize/__main__.py
+++ b/ctale_normalize/__main__.py
@@ -15,8 +15,8 @@ def main():
     parser.add_argument("coordinates", type=str,
                         help="""Coordinates of the captured region in UCSC
                         format. If multiple regions (one per chromosome!) were
-                        captured, write comma-separated coordinates for each
-                        of them""")
+                        captured, write semicolon-separated coordinates for
+                        each of them""")
     parser.add_argument("--mult_factor", type=float, default=1.54,
                         required=False,
                         help="Factor for correction of zone 3")
@@ -29,8 +29,8 @@ def main():
 
     args = parser.parse_args()
 
-#    logging.basicConfig(format='%(message)s',
-#                        level=getattr(logging, args.logLevel))
+    logging.basicConfig(format='%(message)s',
+                        level=getattr(logging, 'INFO'))
 
     C=cooler.Cooler(args.cooler) #load coolfile
     logging.info('Loaded cool')
@@ -47,8 +47,9 @@ def main():
         logging.info('Loaded matrix for %s' % chrom)
         #Perform normalization
         logging.info('Normalization...')
-        mtxs.append(CTALE_norm_iterative(mtx, start, end, C.binsize, steps=args.IC_steps,
-                               mult=args.mult_factor))
+        mtxs.append(CTALE_norm_iterative(mtx, start, end, C.binsize,
+                                         steps=args.IC_steps,
+                                         mult=args.mult_factor))
         chroms.append(chrom)
     logging.info('Save as '+ args.output)
     #Save_coolfile

--- a/ctale_normalize/_version.py
+++ b/ctale_normalize/_version.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+__version__ = '0.1'

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from setuptools import setup
+
+from os import path
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+import re
+VERSIONFILE="ctale_normalize/_version.py"
+verstrline = open(VERSIONFILE, "rt").read()
+VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
+mo = re.search(VSRE, verstrline, re.M)
+if mo:
+    verstr = mo.group(1)
+else:
+    raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
+
+setup(
+      name='CTALE_normalize',
+      version=verstr,
+      packages=['ctale_normalize'],
+      entry_points={
+          'console_scripts': ['ctale_normalize = ctale_normalize.__main__:main']},
+      install_requires=['Cython', 'numpy', 'cooler', 'pandas', 'natsort',
+                        'scipy', 'cooltools'],
+      description='Normalize your C-TALE data!',
+      long_description=long_description,
+      long_description_content_type='text/markdown',
+      project_urls={'Source':'https://github.com/ArtemLuzhin/C-TALE-Normalization',
+                    'Issues':'https://github.com/ArtemLuzhin/C-TALE-Normalization/issues'},
+      author='Artem Luzhin',
+      author_email='artyom.luzhin@gmail.com',
+      classifiers=[
+        "Programming Language :: Python",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ]
+)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
       long_description_content_type='text/markdown',
       project_urls={'Source':'https://github.com/ArtemLuzhin/C-TALE-Normalization',
                     'Issues':'https://github.com/ArtemLuzhin/C-TALE-Normalization/issues'},
-      author='Artem Luzhin',
+      author='Artem Luzhin <artyom.luzhin@gmail.com>, Ilya Flyamer <flyamer@gmail.com>',
       author_email='artyom.luzhin@gmail.com',
       classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
It's all in the title!

It can now be installed with pip. This then makes `ctale_normalize` available in the CLI.
The data I am getting now has two regions captured on different chromosomes, and I want to keep them together, so the tool allows multiple regions, e.g.:

```
ctale_normalize Untreated.hg19.no_filter.1000.mcool::resolutions/10000 chr21:16143248-17096678,chr2:11450601-11945472 Untreated_10000.cool
```

This also has a slight impact on the values in zone 3 - I think due to differences in iterative correction I had to introduce to allow sparse matrices everywhere... Here is an example.

Original result:

![old](https://user-images.githubusercontent.com/2895034/66664343-4325e900-ec44-11e9-81ee-3e2503f858aa.png)

New result:
![new](https://user-images.githubusercontent.com/2895034/66664368-4d47e780-ec44-11e9-89fe-119f63c6858c.png)

As you can see, as a side effect the new version also preserves data outside of the region (but it only saves chromosomes with regions). I think this can be useful, but can be easily changed back.

I am happy to test it on one of your datasets to make sure the changes are not significant, but I don't have any good C-TALE data myself yet...

Let me know what you think!