### PR TITLE
Fix rescaling, add ignore_diags

### DIFF
--- a/ctale_normalize/C_TALE_normalize.py
+++ b/ctale_normalize/C_TALE_normalize.py
@@ -135,7 +135,7 @@ def CTALE_norm_iterative(mtx, ROI_start, ROI_end, resolution, mult=1.54,
         cov = get_cov(mtx.multiply(weights).multiply(weights[np.newaxis].T).tocsr(),
                                start_bin, end_bin)
         cov[bad_bins] = np.nan
-        var = np.var(cov[start_bin:end_bin+1][~(bad_bins-start_bin)])
+        var = np.nanvar(cov[start_bin:end_bin+1])
         logging.info('Iteration %s: var: %s' % (i, var))
         if var < tolerance:
             logging.info('Variance below %s' % tolerance)

--- a/ctale_normalize/__main__.py
+++ b/ctale_normalize/__main__.py
@@ -32,6 +32,9 @@ def main():
                     required=False,
                     help="""Median absolute deviation filter value to remove
                             very low/high covered bins""")
+    parser.add_argument("--ignore_diags", type=int, default=2,
+                    required=False,
+                    help="""How many diagonals to ignore for iterative correction""")
 #    parser.add_argument("output", type=str,
 #                        help="Where to save the output")
 
@@ -61,7 +64,8 @@ def main():
                                                         steps=args.IC_steps,
                                                         mult=args.mult_factor,
                                                         tolerance=args.tolerance,
-                                                        mad_cutoff=args.MAD_max)
+                                                        mad_cutoff=args.MAD_max,
+                                                        ignore_diags=args.ignore_diags)
         info = {'tol':args.tolerance,
                 'mad_max':args.MAD_max,
                 'converged':converged}


### PR DESCRIPTION
Fixing https://github.com/ArtemLuzhin/C-TALE-Normalization/issues/4 @golova-n  - as mentioned, now weights of bins outside ROI are simply set to `mult_factor` (this way the `mult_factor` is also stored in the file, btw, for future reference). Multiplication definitely works now :)
![test](https://user-images.githubusercontent.com/2895034/74149748-67003800-4c00-11ea-8c24-8b1ee6b25081.png)

Also added filtering of diagonals for balancing, 2 diagonals by default.

Let me know what you think.